### PR TITLE
Declaring tests as an object

### DIFF
--- a/Munit.coffee
+++ b/Munit.coffee
@@ -70,7 +70,7 @@ class Munit
         suiteTests = []
         for key, test of testSuite['tests']
           test = { func:test } if _.isFunction(test)
-          test.name ?= _.humanize(key)
+          test.name ?= key
           suiteTests.push(test)
         testSuite['tests'] = suiteTests
 

--- a/package.js
+++ b/package.js
@@ -13,6 +13,6 @@ Package.on_use(function (api, where) {
 });
 
 Package.on_test(function(api) {
-    api.use(["coffeescript","tinytest","test-helpers","chai","munit", "underscore-string-latest"]);
+    api.use(["coffeescript","tinytest","test-helpers","chai","munit"]);
     api.add_files("tests/TestRunnerTest.coffee")
 });

--- a/smart.json
+++ b/smart.json
@@ -7,7 +7,6 @@
   "git": "https://github.com/spacejamio/meteor-munit.git",
   "packages": {
     "chai": "0.1.5",
-    "sinon": "0.1.5",
-    "underscore-string-latest": "2.3.3"
+    "sinon": "0.1.5"
   }
 }

--- a/tests/TestRunnerTest.coffee
+++ b/tests/TestRunnerTest.coffee
@@ -391,8 +391,8 @@ catch err
 
 class TestsAsObjectSuiteTest
   tests:
-    simpleTest: (test) -> test.equal(test.test_case.shortName, 'Simple test')
-    'my test': (test) -> test.equal(test.test_case.shortName, 'My test')
+    simpleTest: (test) -> test.equal(test.test_case.shortName, 'simpleTest')
+    'My Test': (test) -> test.equal(test.test_case.shortName, 'My Test')
 
     foo:
       name: 'My explicit name'


### PR DESCRIPTION
See issue: https://github.com/spacejamio/meteor-munit/issues/4#issuecomment-47564140

This allows for really clean declarations within coffeescript, like this:

```
tests:
  myTest1: (test) -> # Name parsed to "My Test 1"
  myTest2:
    skip: true
    func: (test) -> # Name parsed to "My Test 2"
```
