### PR TITLE
Increase default timeouts and add Munit.wrap and Munit.lastError

### DIFF
--- a/Munit.coffee
+++ b/Munit.coffee
@@ -1,5 +1,16 @@
 class Munit
 
+  @lastError: null
+
+  @wrap: (func)->
+    chai.expect(func).to.be.a('function')
+    return ->
+      Munit.lastError = null
+      try
+        func()
+      catch ex
+        Munit.lastError = ex
+        throw ex
 
   @run:(testSuite)->
     chai.expect(testSuite).to.be.an('object')
@@ -79,7 +90,7 @@ class Munit
         chai.expect(test).to.have.property('name')
         chai.expect(test).to.have.property('func')
         if not test.skip
-          test.timeout = test.timeout || 5000
+          test.timeout = test.timeout || 30000
           if test.type is "client"
             if Meteor.isClient
               arrTests.push test

--- a/async_multi.js
+++ b/async_multi.js
@@ -115,7 +115,7 @@ lvTestAsyncMulti = function (name,timeout,funcs) {
   // Backward compatibility
   if( Array.isArray(timeout) ){
     funcs = timeout;
-    timeout = 5000; // 5 seconds
+    timeout = 30000; // 5 seconds
   }
 
   Tinytest.addAsync(name, function (test, onComplete) {

--- a/tests/HelpersTest.coffee
+++ b/tests/HelpersTest.coffee
@@ -8,3 +8,23 @@ describe "Munit.stubs", ->
   it "should exist", ->
     expect(Munit.stubs).to.be.an 'object'
     expect(Munit.stubs.restoreAll).to.be.a 'function'
+
+
+describe "Munit.wrap", ->
+  it "should set Munit.lastError to the thrown exception", ->
+    fn = (msg)->
+      throw new Error(msg)
+
+    expect(Munit.wrap(->fn("wrapped"))).to.throw(Error, 'wrapped')
+    expect(Munit.lastError).to.be.instanceof Error
+    expect(Munit.lastError.message).to.equal 'wrapped'
+
+
+describe "Munit.wrap", ->
+  it "should set Munit.lastError to null if not excpetion was thrown", ->
+    fn = (msg)->
+      return
+
+    expect(Munit.wrap(->fn("wrapped"))).to.not.throw()
+    expect(Munit.lastError).to.be.null
+


### PR DESCRIPTION
To analyze exceptions thrown from functions under test.
